### PR TITLE
Fix #48: Made tab name not overflow

### DIFF
--- a/src/components/document.svelte
+++ b/src/components/document.svelte
@@ -66,9 +66,9 @@
 
 <!-- TODO: Decide whether not open tabs should be hidden or removed from DOM -->
 <div class={`${open ? "" : "hidden"} flex flex-col w-full max-w-screen-xl`}>
-  <div class="flex h-[80px] mb-6 mx-auto justify-center w-[50%] min-w-[300px]">
+  <div class="flex mb-6 mx-auto justify-center w-[50%] min-w-[300px]">
     <textarea
-      class="w-full h-full resize-none border-none bg-base rounded-lg py-7 text-text text-[2rem] focus:outline-none focus:ring-0 shadow-lg"
+      class="w-full h-full leading-normal flex content-center resize-none border-none bg-base rounded-lg text-text text-[2rem] focus:outline-none focus:ring-0 shadow-lg"
       placeholder="Enter title here..."
       value={documentTitle}
       oninput={handleTitleChange}

--- a/src/components/sidebar.svelte
+++ b/src/components/sidebar.svelte
@@ -10,9 +10,9 @@
   const editor: any = getContext("editor");
 </script>
 
-<main class="h-full basis-[40px] grow-0 shrink-0 border-r-2 border-r-surface0">
+<main class="h-full basis-[40px] py-2 grow-0 shrink-0 border-r-2 border-r-surface0">
   <div class="flex flex-col justify-between h-full">
-    <div class="flex flex-col mt-[10px] py-[10px] px-[2px] gap-3">
+    <div class="flex flex-col px-[2px] gap-3">
       <button
         class="flex justify-center rounded-lg items-center h-5 px-0.5 py-4 w-full cursor-pointer hover:bg-gray-200/10 transition-all duration-200 focus:outline-none focus:ring-0"
         id="CommandPalette_button"
@@ -28,27 +28,23 @@
       <button
         class="flex justify-center rounded-lg items-center h-5 px-0.5 py-4 w-full cursor-pointer hover:bg-text/10 transition-all duration-200 focus:outline-none focus:ring-0"
         id="Files_Menu_button"
-        onclick={() => RecentFilesMenuStore.toggleVisibility()}
+        onclick={(e: MouseEvent) => {
+          e.stopPropagation()
+          RecentFilesMenuStore.toggleVisibility()
+        }}
         aria-label="Open Files Menu"
         title="Open Files Menu"
       >
         <RecentFilesIcon />
       </button>
     </div>
-    <div class="flex flex-col mb-[5px] py-[10px] px-[2px] gap-3">
-      <button
-        class="flex justify-center rounded-lg items-center h-5 px-0.5 py-4 w-full cursor-pointer hover:bg-text/10 transition-all duration-200 focus:outline-none focus:ring-0"
-        id="Settings_button"
-        onclick={(e) => {
+
+    <div>
+      <SettingsMenu onclick={(e: MouseEvent) => {
           e.stopPropagation();
           SettingsMenuStore.toggleSettingsMenu();
         }}
-        aria-label="Open Settings Menu"
-        title="Open Settings Menu"
-      >
-        <SettingsIcon />
-      </button>
-      <SettingsMenu />
+      />
     </div>
   </div>
 </main>

--- a/src/components/titlebar.svelte
+++ b/src/components/titlebar.svelte
@@ -73,15 +73,17 @@
   >
     {#each tabs as tab}
       <button
-        class={`flex justify-left items-center px-4 text-nowrap h-[30px] min-w-[120px] rounded-[18px] flex-shrink text-text hover:bg-surface1 ${currentTab?.id === tab.id ? "bg-surface0" : ""}`}
+        class="flex justify-left items-center px-4 h-[30px] w-48 rounded-[18px] flex-shrink text-text hover:bg-surface1"
+        class:bg-surface0={currentTab?.id === tab.id}
         class:active={currentTab?.id === tab.id}
         role="tab"
         aria-controls="editor"
         onclick={() => onOpenTab(tab)}
       >
-        {tab.title.length > 20
-          ? tab.title.slice(0, 20) + "..."
-          : tab.title || "Untitled"}
+        <!-- truncate needs to be in a separate span to work properly somehow -->
+        <span class="truncate text-clip">
+          { tab.title || "Untitled" }
+        </span>
       </button>
     {/each}
 


### PR DESCRIPTION
Aside from making tabs not overflow and become fixed sized, I've also went in and made the settings icon and the rest of the icons have a space between them as planned. When doing so I noticed that the settings menu popup position was hardcoded, so I went in and made the code compute its position instead so it could be correctly positioned.

I've also fixed the spacing when a title wraps up to the second line, so things should look a bit better now and not have the cursor run into the first line because of how cramped it was.

![image](https://github.com/user-attachments/assets/55d28f43-38d8-4a9b-91a2-2cc2a85f8fce)
![image](https://github.com/user-attachments/assets/a3461994-c0b5-47da-9234-da4bc816e7da)

