### PR TITLE
fix: improve behavior of keyboard shortcuts to mitigate race condition

### DIFF
--- a/src/components/command-palette.svelte
+++ b/src/components/command-palette.svelte
@@ -15,14 +15,14 @@
   }
 
   let commands: Command[] = [
-    // {
-    //   name: "Delete Tab",
-    //   shortcut: "Ctrl + D",
-    //   action: () => {
-    //     DocumentService.deleteDocumentTab();
-    //     CommandPaletteStore.toggleVisibility();
-    //   },
-    // },
+    {
+       name: "Delete Tab",
+       shortcut: "Ctrl + D",
+       action: () => {
+         DocumentService.deleteDocumentTab();
+         CommandPaletteStore.toggleVisibility();
+       },
+    },
     {
       name: "Close Tab",
       shortcut: "Ctrl + C",

--- a/src/components/home-hotkeys.svelte
+++ b/src/components/home-hotkeys.svelte
@@ -4,11 +4,21 @@
     import CommandPaletteStore from "../stores/command-palette.store";
     import ContentEditorStore from "../stores/content-editor.store";
 
+    let activeKeys = new Set();
+
+    const handleKeyup = (event: KeyboardEvent): void => {
+        // remove the keys from the activeKeys set
+        activeKeys.delete(event.key)
+    }
     const handleKeydown = (event: KeyboardEvent): void => {
-        // if (event.ctrlKey && event.key === "d") {
-        //     event.preventDefault();
-        //     DocumentService.deleteDocumentTab();
-        // }
+        // check if key is already in the activeKeys set 
+        if (!activeKeys.has(event.key)) {
+            activeKeys.add(event.key);
+        } else return;
+        if (event.ctrlKey && event.key === "d") {
+             event.preventDefault();
+             DocumentService.deleteDocumentTab();
+        }
         if (event.ctrlKey && event.key === "c") {
             event.preventDefault();
             TabService.closeTab();
@@ -47,4 +57,4 @@
     }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window on:keydown={handleKeydown} on:keyup={handleKeyup} />


### PR DESCRIPTION
- Greatly improved this behavior in a simple way, by creating an active key set that registers each key when pressed, and a function to detect a "key up" event and remove the key from the set 
- Behavior now similar to that of Obsidian which prevents the user from holding down keyboard shortcuts to spam a command.
- User can still quickly press and release the shortcut keys, but it becomes much more deliberate and harder to induce this race condition.